### PR TITLE
Update 2014_10_12_000000_create_users_table.php

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -20,6 +20,7 @@ class CreateUsersTable extends Migration
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 


### PR DESCRIPTION
Adding soft delete migrations to prevent error.
* If this is not a part of migration, deleted_at column will not exist and it will cause errors.